### PR TITLE
Add CI and auto-versioning

### DIFF
--- a/.github/workfows/build.yml
+++ b/.github/workfows/build.yml
@@ -1,0 +1,87 @@
+name: "Build and Publish"
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.gitignore"
+      - "**/*.gitattributes"
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.gitignore"
+      - "**/*.gitattributes"
+  workflow_dispatch:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "**/*.gitignore"
+      - "**/*.gitattributes"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x" # Updated Node.js version
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install vsce
+        run: npm install -g @vscode/vsce
+
+      - name: 🏷️ NBGV
+        uses: dotnet/nbgv@master
+        id: nbgv
+        with:
+          stamp: package.json
+
+      - name: 🗣️ NBGV outputs
+        run: |
+          echo "SimpleVersion: ${{ steps.nbgv.outputs.SimpleVersion }}"
+
+      - name: Package
+        run: npm run package
+
+      - name: Extract Package Version
+        id: package_version
+        uses: Saionaro/extract-package-version@v1.2.1
+
+      - name: Publish
+        if: ${{ github.event_name == 'push' }}
+        run: npm run deploy
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.repository.name }}.vsix
+          path: |
+            **/*.vsix
+
+      - name: 🏷️ Tag and Release
+        id: tag_release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          body: Release ${{ steps.nbgv.outputs.SimpleVersion }}
+          tag_name: ${{ steps.nbgv.outputs.SimpleVersion }}
+          generate_release_notes: true
+          files: |
+            **/*.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,5 +7,9 @@ webpack.config.js
 vsc-extension-quickstart.md
 **/tsconfig.json
 **/.eslintrc.json
+**/eslint.config.mjs
 **/*.map
 **/*.ts
+version.json
+node_modules/nerdbank-gitversioning/
+.github/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
 	"name": "promptboost",
-	"version": "0.1.0",
+	"version": "0.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "promptboost",
-			"version": "0.1.0",
+			"version": "0.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/chat-extension-utils": "^0.0.0-alpha.1",
-				"@vscode/prompt-tsx": "^0.3.0-alpha.12"
+				"@vscode/prompt-tsx": "^0.3.0-alpha.12",
+				"nerdbank-gitversioning": "^3.8.38-alpha"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.13.0",
@@ -1272,6 +1273,16 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/nerdbank-gitversioning": {
+			"version": "3.8.38-alpha",
+			"resolved": "https://registry.npmjs.org/nerdbank-gitversioning/-/nerdbank-gitversioning-3.8.38-alpha.tgz",
+			"integrity": "sha512-LPwDbgEkkcXffaqP80Pl1QccYibl1xe+1tJrUr7zVm/RIg9f9LfCbfsAYMomzUz5iAtiPztqe29HS3gfDcUHow==",
+			"license": "MIT",
+			"bin": {
+				"nbgv": "main.js",
+				"nbgv-setversion": "npmVersion.js"
+			}
 		},
 		"node_modules/optionator": {
 			"version": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
 		"type": "git",
 		"url": "https://github.com/chrisdias/vscode-promptboost"
 	},
+	"qna": "https://github.com/chrisdias/vscode-promptboost/issues",
+	"author": {
+		"name": "Chris Dias"
+	},
 	"icon": "resources/icon.png",
 	"license": "MIT",
 	"version": "0.8.0",
@@ -81,7 +85,8 @@
 	},
 	"dependencies": {
 		"@vscode/chat-extension-utils": "^0.0.0-alpha.1",
-		"@vscode/prompt-tsx": "^0.3.0-alpha.12"
+		"@vscode/prompt-tsx": "^0.3.0-alpha.12",
+		"nerdbank-gitversioning": "^3.8.38-alpha"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.13.0",

--- a/version.json
+++ b/version.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.8",
+    "publicReleaseRefSpec": [
+        "^refs/heads/main$",
+        "^refs/tags/v\\d+\\.\\d+"
+    ],
+    "cloudBuild": {
+        "buildNumber": {
+            "enabled": true
+        }
+    }
+}


### PR DESCRIPTION
# Description
Adds some CI and auto-versioning of the package.  Defaults to 0.8.* versioning where * is the build number which will auto-increment. To change either major/minor change in version.json to bump either the major/minor and let revision auto number.

NEEDS: GitHub repository secret named `VSCE_PAT` for your marketplace publisher account
RUNS ON: Push to main branch and manually triggered

# Changes proposed in this PR:
- Adds nerdbank versioning
- Change qna to Issues repo
- Add build/publish workflow